### PR TITLE
Reduce CMake to 2.7, Visual C++ Compiler Tweaks, 64bit CrashFix, SDL_Delay BugFix

### DIFF
--- a/rte/.gitignore
+++ b/rte/.gitignore
@@ -1,0 +1,11 @@
+.vs
+CMakeSettings.json
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake

--- a/rte/CMakeLists.txt
+++ b/rte/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.7)
 project(rte)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/rte/CMakeSettings.json.example
+++ b/rte/CMakeSettings.json.example
@@ -1,0 +1,109 @@
+{
+  // See https://go.microsoft.com//fwlink//?linkid=834763 for more information about this file.
+  "configurations": [
+    {
+      "name": "x86-Debug",
+      "generator": "Visual Studio 15 2017",
+      "configurationType": "Debug",
+      "buildRoot": "${env.LOCALAPPDATA}\\CMakeBuild\\${workspaceHash}\\build\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-m -v:minimal",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "x86-Release",
+      "generator": "Visual Studio 15 2017",
+      "configurationType": "Release",
+      "buildRoot": "${env.LOCALAPPDATA}\\CMakeBuild\\${workspaceHash}\\build\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-m -v:minimal",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "x64-Debug",
+      "generator": "Visual Studio 15 2017 Win64",
+      "configurationType": "Debug",
+      "buildRoot": "${env.LOCALAPPDATA}\\CMakeBuild\\${workspaceHash}\\build\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-m -v:minimal",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "SDL2_PATH",
+          "value": "C:\\cpp\\SDL2-2.0.5"
+        },
+        {
+          "name": "SDL2_IMAGE_PATH",
+          "value": "C:\\cpp\\SDL2_image-2.0.1"
+        },
+        {
+          "name": "SDL2_TTF_PATH",
+          "value": "C:\\cpp\\SDL2_ttf-2.0.14"
+        },
+        {
+          "name": "SDL2_MIXER_INCLUDE_DIR",
+          "value": "C:\\cpp\\SDL2_mixer-2.0.1\\include"
+        },
+        {
+          "name": "SDL2_MIXER_LIBRARY",
+          "value": "C:\\cpp\\SDL2_mixer-2.0.1\\lib\\x64\\SDL2_mixer.lib"
+        },
+        {
+          "name": "Squirrel_DIR",
+          "value": "C:\\cpp\\squirrel3\\include"
+        },
+        {
+          "name": "Squirrel_LIBRARY",
+          "value": "C:\\cpp\\squirrel3\\lib\\x64\\Debug\\squirrel.lib"
+        },
+        {
+          "name": "Squirrel_STD_LIBRARY",
+          "value": "C:\\cpp\\squirrel3\\lib\\x64\\Debug\\sqstdlib.lib"
+        }
+      ]
+    },
+    {
+      "name": "x64-Release",
+      "generator": "Visual Studio 15 2017 Win64",
+      "configurationType": "Release",
+      "buildRoot": "C:\\Users\\xingo\\Documents\\c++\\XYG-Studio-master\\rte\\bin",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-m -v:minimal",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "SDL2_PATH",
+          "value": "C:\\cpp\\SDL2-2.0.5"
+        },
+        {
+          "name": "SDL2_IMAGE_PATH",
+          "value": "C:\\cpp\\SDL2_image-2.0.1"
+        },
+        {
+          "name": "SDL2_TTF_PATH",
+          "value": "C:\\cpp\\SDL2_ttf-2.0.14"
+        },
+        {
+          "name": "SDL2_MIXER_INCLUDE_DIR",
+          "value": "C:\\cpp\\SDL2_mixer-2.0.1\\include"
+        },
+        {
+          "name": "SDL2_MIXER_LIBRARY",
+          "value": "C:\\cpp\\SDL2_mixer-2.0.1\\lib\\x64\\SDL2_mixer.lib"
+        },
+        {
+          "name": "Squirrel_DIR",
+          "value": "C:\\cpp\\squirrel3\\include"
+        },
+        {
+          "name": "Squirrel_LIBRARY",
+          "value": "C:\\cpp\\squirrel3\\lib\\x64\\Release\\squirrel.lib"
+        },
+        {
+          "name": "Squirrel_STD_LIBRARY",
+          "value": "C:\\cpp\\squirrel3\\lib\\x64\\Release\\sqstdlib.lib"
+        }
+      ]
+    }
+  ]
+}

--- a/rte/DEVELOP.md
+++ b/rte/DEVELOP.md
@@ -1,0 +1,101 @@
+# Development Guide
+
+This guide is to help programmers get on boarded with various IDEs and compilers to work on the game engine.
+
+## Visual Studio 2017 - CMake
+
+### Required Libraries
+
+#### Fast Tracking
+If you are building for `64bit` you can download an example structure of the following C++ libraries which will work with the existing documentation below.
+
+    - Source Headers & Libraries - [c:\cpp](https://drive.google.com/open?id=0BwInc8An2aOMOGpjc2pRTU9wblE)
+    - RTE Runtime / DLLs - [{REPO}\rte\bin](https://drive.google.com/open?id=0BwInc8An2aOMN0VBN3VkbUpKZjQ)
+
+Install `Source Headers & Libraries` to C:\ and install `RTE Runtime / DLLs` to where this github repo is `{REPO}\rte\bin` it will have all the DLLs needed to run the application.
+
+#### Custom Setup
+
+You will need SDL and various SDL libraries, and Squirrel. Please be very aware of the builds you download as they could be for 32bits or 64bits and the game engine needs to compile against the right platform.
+
+    - SDL2
+    - SDL2_Image
+    - SDL2_Mixer
+    - SDL2_TTF
+    - Squirrel 3.1
+
+Visual Studo 2017 includes the ability to run CMake right from the editor. CMake has had Visual Studio Support, but that was running CMake outside of Visual Studo to generate the Visual Studio Solution/Projects. With Visual Studio you can just open the development folder that has `CMakeLists.txt`. From there it will run CMake and provide compile options from there. Here is how you open the folder:
+
+ 1. Install / Open Visual Studio 2017
+ 1. Make sure you have **Desktop development with C++** installed / enabled, if you do not, then do the following:
+    1. Go to File -> New Project
+    1. At the bottom left of the window there will be *Not finding what you are looking for?* then under it, it will say "Open Visual Studio Installer".
+    1. Install **Desktop development with C++**
+ 1. Next go to File -> Open and find the folder that has `CMakeLists.txt`
+ 1. Visual Studio will start to process the CMake file and fail, this is expected. We need to specify where the needed libraries and includes are. While CMake is very portable its not 100% portable specifically for Windows based development.
+ 1. At this point we will want to edit the CMake settings. You can do this by right-clicking the `CMakeLists.txt` in the **Solution Explorer**. Then, choose `Change CMake Settings`. This will then generate `CMakeSettings.json` with various build types.
+ 1. At this point there will be 2-4 enteries in the JSON file and may look like this:
+
+        {
+        // See https://go.microsoft.com//fwlink//?linkid=834763 for more information about this file.
+        "configurations": [
+            ...
+            {
+            "name": "x64-Debug",
+            "generator": "Visual Studio 15 2017 Win64",
+            "configurationType": "Debug",
+            "buildRoot": "${env.LOCALAPPDATA}\\CMakeBuild\\${workspaceHash}\\build\\${name}",
+            "cmakeCommandArgs": "",
+            "buildCommandArgs": "-m -v:minimal",
+            "ctestCommandArgs": ""
+            },
+            ...
+        ]
+        }
+    We want to add in the CMake varibles to various SDL & Squirrel folders. Here is an example build:
+
+        {
+        "name": "x64-Debug",
+        "generator": "Visual Studio 15 2017 Win64",
+        "configurationType": "Debug",
+        "buildRoot": "${env.LOCALAPPDATA}\\CMakeBuild\\${workspaceHash}\\build\\${name}",
+        "cmakeCommandArgs": "",
+        "buildCommandArgs": "-m -v:minimal",
+        "ctestCommandArgs": "",
+        "variables": [
+            {
+            "name": "SDL2_PATH",
+            "value": "C:\\cpp\\SDL2-2.0.5"
+            },
+            {
+            "name": "SDL2_IMAGE_PATH",
+            "value": "C:\\cpp\\SDL2_image-2.0.1"
+            },
+            {
+            "name": "SDL2_TTF_PATH",
+            "value": "C:\\cpp\\SDL2_ttf-2.0.14"
+            },
+            {
+            "name": "SDL2_MIXER_INCLUDE_DIR",
+            "value": "C:\\cpp\\SDL2_mixer-2.0.1\\include"
+            },
+            {
+            "name": "SDL2_MIXER_LIBRARY",
+            "value": "C:\\cpp\\SDL2_mixer-2.0.1\\lib\\x64\\SDL2_mixer.lib"
+            },
+            {
+            "name": "Squirrel_DIR",
+            "value": "C:\\cpp\\squirrel3\\include"
+            },
+            {
+            "name": "Squirrel_LIBRARY",
+            "value": "C:\\cpp\\squirrel3\\lib\\x64\\Debug\\squirrel.lib"
+            },
+            {
+            "name": "Squirrel_STD_LIBRARY",
+            "value": "C:\\cpp\\squirrel3\\lib\\x64\\Debug\\sqstdlib.lib"
+            }
+        ]
+        },
+ 1. One thing to note is Visual Studio uses the build root as `"${env.LOCALAPPDATA}\\CMakeBuild\\${workspaceHash}\\build\\${name}"` which places this in places the folder in a place like `C:\Users\xingo\AppData\Local\CMakeBuild\61a2373d-b2ef...`. That is annoying at best. You can change it to anything you want like: `"buildRoot": "C:\\Users\\xingo\\Documents\\c++\\XYG-Studio-master\\rte\\bin\\${name}",`
+ 1. Don't forget when you are building for x86_64 or x64 CHANGE THE PROJECT SETTINGS. If you are just running through this document and finding out that SDL is still not being found, then its probably because you are using the wrong build profile.

--- a/rte/binds.cpp
+++ b/rte/binds.cpp
@@ -202,9 +202,9 @@ SQInteger sqLoadImageKeyed(HSQUIRRELVM v){
 };
 
 SQInteger sqSetBackgroundColor(HSQUIRRELVM v){
-	Uint32 color;
+	SQInteger color;
 
-	sq_getinteger(v, 2, (SQInteger*)&color);
+	sq_getinteger(v, 2, &color);
 
 	xySetBackgroundColor(color);
 

--- a/rte/cmake/FindSDL2_mixer.cmake
+++ b/rte/cmake/FindSDL2_mixer.cmake
@@ -67,10 +67,6 @@
 #
 #=============================================================================
 
-if(NOT SDL2_MIXER_INCLUDE_DIR AND SDL2MIXER_INCLUDE_DIR)
-    set(SDL2_MIXER_INCLUDE_DIR ${SDL2MIXER_INCLUDE_DIR} CACHE PATH "directory cache
-entry initialized from old variable name")
-endif()
 find_path(SDL2_MIXER_INCLUDE_DIR SDL_mixer.h
         HINTS
         ENV SDL2MIXERDIR
@@ -78,6 +74,7 @@ find_path(SDL2_MIXER_INCLUDE_DIR SDL_mixer.h
         PATH_SUFFIXES SDL2
         # path suffixes to search inside ENV{SDL2DIR}
         include/SDL2
+		PATHS ${SDL2_MIXER_PATH}
         )
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
@@ -86,16 +83,13 @@ else()
     set(VC_LIB_PATH_SUFFIX lib/x86)
 endif()
 
-if(NOT SDL2_MIXER_LIBRARY AND SDL2MIXER_LIBRARY)
-    set(SDL2_MIXER_LIBRARY ${SDL2MIXER_LIBRARY} CACHE FILEPATH "file cache entry
-initialized from old variable name")
-endif()
 find_library(SDL2_MIXER_LIBRARY
         NAMES SDL2_mixer
         HINTS
         ENV SDL2MIXERDIR
         ENV SDL2DIR
         PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+		PATHS ${SDL2_MIXER_PATH}
         )
 
 if(SDL2_MIXER_INCLUDE_DIR AND EXISTS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h")

--- a/rte/cmake/FindSquirrel.cmake
+++ b/rte/cmake/FindSquirrel.cmake
@@ -7,9 +7,23 @@
 #  Squirrel_STD_LIBRARY - The Squirrel std library
 
 
-FIND_PATH(Squirrel_INCLUDE_DIR squirrel.h PATH_SUFFIXES squirrel)
-FIND_LIBRARY(Squirrel_LIBRARY NAMES squirrel PATH_SUFFIXES squirrel)
-FIND_LIBRARY(Squirrel_STD_LIBRARY NAMES sqstdlib PATH_SUFFIXES squirrel)
+FIND_PATH(Squirrel_INCLUDE_DIR squirrel.h 
+        HINTS
+        PATH_SUFFIXES squirrel
+		PATHS ${Squirrel_DIR}
+		)
+
+FIND_LIBRARY(Squirrel_LIBRARY 
+		NAMES squirrel
+		PATH_SUFFIXES squirrel
+		PATHS ${Squirrel_DIR}
+		)
+
+FIND_LIBRARY(Squirrel_STD_LIBRARY
+		NAMES sqstdlib
+		PATH_SUFFIXES squirrel
+		PATHS ${Squirrel_DIR}
+		)
 
 MARK_AS_ADVANCED(Squirrel_INCLUDE_DIR Squirrel_LIBRARY)
 

--- a/rte/main.cpp
+++ b/rte/main.cpp
@@ -431,7 +431,12 @@ void xyUpdate(){
 
 	gvFPS = 1000 / fLength;
 	//Wait for FPS limit
-	if(gvMaxFPS != 0) SDL_Delay((1000 / gvMaxFPS) - (fLength / gvMaxFPS));
+	//		delay	4294967290	unsigned int
+	Uint32 current_time = (static_cast<Uint32>(fLength) / gvMaxFPS);
+	Uint32 max_delay = (1000 / gvMaxFPS);
+	if (current_time < max_delay) {
+		if (gvMaxFPS != 0) SDL_Delay(max_delay - current_time);
+	}
 	/*while(fLength < 1000 / gvMaxFPS){
 		gvTicks = SDL_GetTicks();
 		fLength = gvTicks - gvTickLast;

--- a/rte/main.h
+++ b/rte/main.h
@@ -17,6 +17,14 @@
 #include <sys/stat.h>
 #include <iostream>
 #include <limits>
+
+#ifdef _MSC_VER
+#ifndef PATH_MAX
+#define PATH_MAX _MAX_PATH
+#endif
+#define realpath(N,R) _fullpath((R),(N),_MAX_PATH)
+#endif
+
 #ifdef _WIN32
 	#include <direct.h>
 #else


### PR DESCRIPTION
Clion and Visual Studio both ships with CMake 2.7 and the required CMake was set to 2.8. Reducing it doesn't hurt since there were no 2.8 features used.

The other issue is MSVC compiler does not support realpath and has it own methods for it. So some changes were made to support MSVC.