### PR TITLE
xyPrint xyError Issues

### DIFF
--- a/rte/CMakeLists.txt
+++ b/rte/CMakeLists.txt
@@ -41,6 +41,10 @@ set(SOURCE_FILES
         text.cpp
         text.h)
 
+configure_file(${CMAKE_SOURCE_DIR}/bin/xylib/core.nut ${CMAKE_BINARY_DIR}/bin/xylib/core.nut COPYONLY)
+configure_file(${CMAKE_SOURCE_DIR}/bin/xylib/shapes.nut ${CMAKE_BINARY_DIR}/bin/xylib/shapes.nut COPYONLY)
+configure_file(${CMAKE_SOURCE_DIR}/bin/xylib/tmx.nut ${CMAKE_BINARY_DIR}/bin/xylib/tmx.nut COPYONLY)
+
 add_executable(rte ${SOURCE_FILES})
 
 target_link_libraries(rte ${SDL2_LIBRARY}

--- a/rte/DEVELOP.md
+++ b/rte/DEVELOP.md
@@ -2,6 +2,17 @@
 
 This guide is to help programmers get on boarded with various IDEs and compilers to work on the game engine.
 
+## CLion - MacOS
+
+If you are using brew you can simply run the following:
+
+    brew install sdl2 sdl2_image sdl2_mixer sdl2_ttf squirrel
+
+Then in Clion just open `{project_path}/rte` and you are set! A tip for running Squirrels from the IDE is to edit the `rte` configuration set:
+
+ - **Program arguments**: your .nut or .sq file here
+ - **Working directory**: the directory where you want to reference your files, its not really needed as RTE will switch the directory based on the nut file, but this lets you not have to enter in the full path to your nut file.
+
 ## Visual Studio 2017 - CMake
 
 ### Required Libraries

--- a/rte/global.cpp
+++ b/rte/global.cpp
@@ -11,7 +11,7 @@ int gvMouseX = 0, gvMouseY = 0;
 Uint32 gvScrW = 320, gvScrH = 240;
 Uint32 gvWinW = 320, gvWinH = 240;
 HSQUIRRELVM gvSquirrel;
-FILE *gvLog;
+ofstream gvLog;
 SDL_Window *gvWindow;
 SDL_Renderer *gvRender;
 SDL_Texture *gvScreen;

--- a/rte/global.h
+++ b/rte/global.h
@@ -12,7 +12,7 @@ extern int gvMouseX, gvMouseY;		//Mouse coordinates
 extern Uint32 gvScrW, gvScrH;		//Screen resolution
 extern Uint32 gvWinW, gvWinH;		//Window resolution
 extern HSQUIRRELVM gvSquirrel;		//Squirrel VM
-extern FILE *gvLog;					//Output log
+extern ofstream gvLog;				//Output log
 extern SDL_Window *gvWindow;		//Main window
 extern SDL_Renderer *gvRender;		//Main renderer
 extern SDL_Texture *gvScreen;		//Main screen texture

--- a/rte/main.cpp
+++ b/rte/main.cpp
@@ -113,7 +113,7 @@ int main(int argc, char* args[]){
 int xyInit(){
 	//Initiate log file
 	remove("log.txt");
-	gvLog = fopen("log.txt", "w");
+	gvLog.open("log.txt");
 
 	//Print opening message
 	xyPrint(0, "\n/========================\\\n| XYG STUDIO RUNTIME LOG |\n\\========================/\n\n");
@@ -179,6 +179,7 @@ int xyInit(){
 	gvSquirrel = sq_open(1024);
 
 	sqstd_register_mathlib(gvSquirrel);
+	sqstd_register_iolib(gvSquirrel);
 	sq_setprintfunc(gvSquirrel, xyPrint, xyError);
 	sq_pushroottable(gvSquirrel);
 
@@ -197,8 +198,8 @@ int xyInit(){
 	vcSounds.push_back(0);
 	vcMusic.push_back(0);
 
-	fprintf(gvLog, "================\n\n");
-	printf("================\n\n");
+	gvLog << "================\n\n";
+	cout << "================\n\n";
 
 	//Return success
 	return 1;
@@ -207,18 +208,18 @@ int xyInit(){
 void xyError(HSQUIRRELVM v, const SQChar *s, ...){
 	va_list args;
 	va_start(args, s);
-	fprintf(gvLog, "!ERROR! >:: ");
-	vfprintf(gvLog, s, args);
-	printf("!ERROR! >:: ");
-	vprintf(s, args);
-	printf("\n\n");
-	fprintf(gvLog, "\n\n");
+	SQChar buffer[1024] = _SC("");
+	vsnprintf(buffer, sizeof(buffer), s, args);
 	va_end(args);
+
+	cout << "!ERROR! >:: " << buffer << endl << endl;
+	gvLog << "!ERROR! >:: " << buffer << endl << endl;
 };
 
 void xyEnd(){
 
-	fprintf(gvLog, "================\n\n");
+	gvLog << "";
+//	fprintf(gvLog, "================\n\n");
 	printf("================\n\n");
 
 	//Cleanup all resources
@@ -241,7 +242,7 @@ void xyEnd(){
 
 	//Close Squirrel
 	xyPrint(0, "Closing Squirrel...");
-	int garbage = sq_collectgarbage(gvSquirrel);
+	SQInteger garbage = sq_collectgarbage(gvSquirrel);
 	xyPrint(0, "Collected %i junk obects.", garbage);
 	sq_pop(gvSquirrel, 1);
 	sq_close(gvSquirrel);
@@ -257,19 +258,18 @@ void xyEnd(){
 
 	//Close log file
 	xyPrint(0, "System closed successfully!");
-	fclose(gvLog);
+	gvLog.close();
 };
 
 void xyPrint(HSQUIRRELVM v, const SQChar *s, ...){
 	va_list args;
 	va_start(args, s);
-	fprintf(gvLog, ">:: ");
-	vfprintf(gvLog, s, args);
-	printf(">:: ");
-	vprintf(s, args);
-	printf("\n\n");
-	fprintf(gvLog, "\n\n");
+	SQChar buffer[1024] = _SC("");
+	vsnprintf(buffer, sizeof(buffer), s, args);
 	va_end(args);
+
+	cout << ">:: " << buffer << endl << endl;
+	gvLog << ">:: " << buffer << endl << endl;
 };
 
 void xyBindFunc(HSQUIRRELVM v, SQFUNCTION func, const SQChar *key){


### PR DESCRIPTION
xyPrint would show gargled text in some situations. xyError would cause a segment fault when Squirrel tried to throw a backtrace. I narrowed it down to vprintf causing the segment fault. If vprintf receives the wrong format for a parameter or the string is too long it can overflow / segment fault. So I've switched it to vsnprintf (safer) and use streams in-place of printing. I did set a hard limit of 1024 characters, this can change if needed but it at least stops the gargled & segment faults.