### PR TITLE
Fix for realpath on mingw32

### DIFF
--- a/rte/main.cpp
+++ b/rte/main.cpp
@@ -117,7 +117,7 @@ int main(int argc, char* args[]){
 int xyInit(){
 	//Initiate log file
 	remove("log.txt");
-	gvLog.open("log.txt", "w");
+	gvLog.open("log.txt", ios_base::out);
 
 	//Print opening message
 	xyPrint(0, "\n/========================\\\n| XYG STUDIO RUNTIME LOG |\n\\========================/\n\n");

--- a/rte/main.h
+++ b/rte/main.h
@@ -7,6 +7,7 @@
 
 //Headers
 #include <stdio.h>
+#include <stdlib.h>
 #include <sstream>
 #include <string>
 #include <stdarg.h>
@@ -18,7 +19,7 @@
 #include <iostream>
 #include <limits>
 
-#ifdef _MSC_VER
+#if defined( _MSC_VER ) || defined( __MINGW32__ )
 #ifndef PATH_MAX
 #define PATH_MAX _MAX_PATH
 #endif


### PR DESCRIPTION
If you are on mingw32 you have access to fullpath. If you Codeblocks and built in mingw32, you need to add "-U__STRICT_ANSI__" to the compiler -> other compiler flags